### PR TITLE
6 lytix timeoveriew use core external

### DIFF
--- a/classes/timeoverview_lib.php
+++ b/classes/timeoverview_lib.php
@@ -28,8 +28,10 @@
 
 namespace lytix_timeoverview;
 
-use core_plugin_manager;
-use lytix_timeoverview\timeoverview;
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once("{$CFG->libdir}/externallib.php");
 
 /**
  * Class timeoverview_lib

--- a/version.php
+++ b/version.php
@@ -30,5 +30,5 @@ $plugin->maturity  = MATURITY_STABLE;
 $plugin->requires  = 2022112800.00; // Requires this Moodle version 4.1.
 $plugin->component    = 'lytix_timeoverview'; // Full name of the plugin.
 $plugin->dependencies = ['lytix_helper' => ANY_VERSION];
-$plugin->release      = 'v1.1.3';
+$plugin->release      = 'v1.1.4';
 $plugin->supported    = [401, 403];


### PR DESCRIPTION
- Change the import of externallib to work for both Moodle 4.1 and 4.2+.
- Change the import to work for Moodle 4.2 and the testmatrix for Moodle 4.2 + PHP 8.2+